### PR TITLE
Return user token when request /api/auth/user.

### DIFF
--- a/mynote-backend/internal/controller/user_controller.go
+++ b/mynote-backend/internal/controller/user_controller.go
@@ -14,5 +14,11 @@ func GetUser(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"user": userId})
+	userToken, err := model.FindUserToken(userId)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"message": "Failed to get user"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"token": userToken.Token})
 }

--- a/mynote-backend/internal/controller/user_controller_test.go
+++ b/mynote-backend/internal/controller/user_controller_test.go
@@ -1,0 +1,58 @@
+package controller_test
+
+import (
+	"MyNote/internal/controller"
+	"MyNote/internal/model"
+	"MyNote/pkg/database/database_test"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gin-gonic/gin"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UserController", Ordered, func() {
+	var db *database_test.DB
+
+	BeforeAll(func() {
+		db = database_test.ConnectTestDb()
+
+		DeferCleanup(func() {
+			db.CloseTestDb()
+		})
+	})
+
+	Context("When get user request", func() {
+		var userToken *model.UserToken
+		var testContext *gin.Context
+		var responseWriter *httptest.ResponseRecorder
+
+		BeforeEach(func() {
+			user, _ := model.CreateUser()
+			userProfile, _ := model.CreateUserProfile("first", "last", "example@example.com", user.ID)
+			userToken, _ = model.CreateUserToken(userProfile)
+
+			responseWriter = httptest.NewRecorder()
+			testContext, _ = gin.CreateTestContext(responseWriter)
+			testContext.Request, _ = http.NewRequest("GET", "/api/auth/user", nil)
+			testContext.Request.Header.Set("Authorization", "Bearer "+userToken.Token)
+		})
+
+		It("Get user token successfully", func() {
+			controller.GetUser(testContext)
+			Expect(testContext.Writer.Status()).To(Equal(http.StatusOK))
+
+			body, _ := ioutil.ReadAll(responseWriter.Body)
+
+			var token struct {
+				Token string `json:"token"`
+			}
+
+			json.Unmarshal([]byte(body), &token)
+			Expect(userToken.Token).To(Equal(token.Token))
+		})
+	})
+})

--- a/mynote-frontend/nuxt.config.js
+++ b/mynote-frontend/nuxt.config.js
@@ -57,7 +57,7 @@ export default {
         endpoints: {
           login: { url: '/api/auth/login', method: 'post', propertyName: 'token' },
           logout: { url: '/api/auth/logout', method: 'post' },
-          user: { url: '/api/auth/user', method: 'get', propertyName: 'user' }
+          user: { url: '/api/auth/user', method: 'get', propertyName: 'token' }
         },
         // tokenRequired: true,
         // tokenType: 'bearer'


### PR DESCRIPTION
Until now, /api/auth/user returns user_id, but user_id could be tampered with. Therefore we change user_id to token which identifies the user.