### PR TITLE
Fix ginkgo option command.

### DIFF
--- a/.github/workflows/ginkgo.yml
+++ b/.github/workflows/ginkgo.yml
@@ -31,5 +31,5 @@ jobs:
         echo "MYSQL_ROOT_PASSWORD=password" >> $GITHUB_ENV
         echo "MYSQL_DATABASE=mynote_test_db" >> $GITHUB_ENV
     - name: Run test
-      run: ginkgo -r --randomize-all --randomize-suites
+      run: ginkgo -r --ginkgo.randomize-all 
       working-directory: ./mynote-backend/


### PR DESCRIPTION
In ginkgo 2.3.1 version, -randomize-all and --randomize-suites option is disabled. Therefore, we could not run the command with the option. Because of it, we fix the command.